### PR TITLE
Changes for file writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,95 +11,6 @@ The WMAgent and Tier0 are responsible for submitting and managing tens of thousa
 Everything is written in python 3.5
 
 ## Dependencies:
-Can be used to make a dependencies tree from *.spec files in chosen directory. 
-In tree graph:
--Ok means that library is supported in python3
--No means that it isn't
-
-Contains 2 files: 
-
-dependencyWriter.py and node.py
-
-dependencyWriter.py Has one required argument: -path 
-
-And two optional: -rName and -tName
-
-For more info run:
-
-python3 dependencyWriter.py -h
-
-results.txt - list of dependencies with annotations if they are supported in python3
-python3AvailableLibs.txt - available python3 libraries
-tree.txt- dependencies tree graph
-
-Example:
-```
-'dependencies'
-  -|'sitedb.spec- no'
-  -|  -|'cherrypy- ok'
-  -|  -|  -|'python- no'
-  -|  -|  -|  -|'expat- no'
-```
-
-
-
-## Conversion:
-
-Converts cheetah templates to Jinja2
-
-**Example:**
-
-Cheetah:
-```HTML
-#from DAS.web.utils import quote
-#set item = $quote($item)
-#set api = $quote($api)
-<!-- sitedb.tmpl -->
-#if $api == "sites"
-<a href="/sitedb/prod/sites/$item">SiteDB</a>
-#else if $api == "people"
-<a href="/sitedb/prod/people/$item">SiteDB</a>
-#end if
-<!-- sitedb.tmpl -->
-```
-Jinja2:
-```HTML
-{% set item = quote(item) %}
-{% set api = quote(api) %}
-<!-- sitedb.tmpl -->
-{% if api == "sites" %}
-<a href="/sitedb/prod/sites/{{item}}">SiteDB</a>
-{% elif api == "people" %}
-<a href="/sitedb/prod/people/{{item}}">SiteDB</a>
-{% endif %}
-<!-- sitedb.tmpl -->
-```	
-	
-To convert cheetah templates to Jina2 need to run script TemplateConverter.py with parameters:
-
-* -p PATH            Directory of .tmpl files that needs to be converted
-* -pc PATHCONVERTED  Path where converted templates should be saved
-* -pm PATHMANUAL     Path where information about failed conversions should be saved
-
-After conversions information about files that could not be converted will be saved in PATHMANUAL/manualConversions.txt
-
-After conversions jinja2.Environment should be setup:
-* Set prefix for line based comments (e.g. ####)
-* Create methods and set them to substitute imported classes (e.g. quote)
-
-## DMWMPythonMigration
-
-Main task: Porting Data & Workflow Management code to python 3
-
-Supervisors: Eric Vaandering, Dirk Hufnagel
-
-Description:
-The WMAgent and Tier0 are responsible for submitting and managing tens of thousands or processing jobs on the Worldwide LHC Computing Grid. DAS and DBS are responsible for tracking data and meta-data of PB of files. This code is in production based on python 2.7. The candidate will work with the development teams to prepare this code for python 3.x, beginning with an audit of the suitability of the external software used and identifying replacements where needed. Automated tools will also be employed to help with this porting.
-
-
-Everything is written in python 3.5
-
-## Dependencies:
 ###### dependencyWriter.py
 Can be used to make a dependencies tree from *.spec files in chosen directory. 
 In tree graph:
@@ -177,8 +88,4 @@ To convert cheetah templates to Jina2 need to run script TemplateConverter.py wi
 * -pm PATHMANUAL     Path where information about failed conversions should be saved
 
 After conversions information about files that could not be converted will be saved in PATHMANUAL/manualConversions.txt
-
-After conversions jinja2.Environment should be setup:
-* Set prefix for line based comments (e.g. ####)
-* Create methods and set them to substitute imported classes (e.g. quote)
 

--- a/Report.md
+++ b/Report.md
@@ -20,3 +20,9 @@ Week3:
 - Read about regex(recursive, conditionals etc.) - tested them out
 - Created IrrevertableData to store info about cheetah expresions that can't be converted
 - Fixed some minor bugs(search for expr. end till the end of file, continue and etc.)
+
+Week4:
+- Reconfigured VM. Fixed the probels I had before. It's up and running.
+- Added more documentation for template converter.
+- Created scrip that analyzes any python project and returs unsupported modules/libs.
+- Some bug fixes (changed how comments are handled, new line removal and etc.).

--- a/conversion/FileWriter.py
+++ b/conversion/FileWriter.py
@@ -13,3 +13,27 @@ class FileWriter(object):
         """
         with open(path, mode='w+', encoding='utf-8') as myfile:
             myfile.write(''.join(lines))
+
+    @staticmethod
+    def convertToString(listOfIrreversibles):
+        """
+        Formats information about failed conversions to string
+
+        :return: formated string
+        """
+        formatedString=[]
+        # get same file names
+        fileNames=set(ir.fileName for ir in listOfIrreversibles)
+        for name in fileNames:
+            # get list of irreversible data from same file
+            sameFile=list(filter(lambda x: x.fileName == name, listOfIrreversibles))
+            formatedString += "_" * 100+"\n"
+            formatedString+="Could not fully convert file: "+name+"\n"
+            formatedString += "_" * 90+"\n"
+            for values in sameFile:
+                replace=lambda x: x if x!="" else "This line was removed\n"
+                formatedString += "In lines: {0} - {1}: {2} experssion could not be converted \n\n" \
+                       "Old code:\n{3}Results:\n{4}\n".format(values.lineStart + 1, values.lineEnd + 1, values.type.value[0],
+                                                        "".join(values.oldValue), replace("".join(values.codeReplacment))+"-"*50)
+        return formatedString
+

--- a/conversion/IrreversibleData.py
+++ b/conversion/IrreversibleData.py
@@ -22,13 +22,4 @@ class IrreversibleData(object):
             raise ValueError("Replacment should be a list")
         self._codeReplacment = replacment
 
-    def __str__(self):
-        """
-        Formats information about failed conversions to string
 
-        :return: formated string
-        """
-        return "Could not fully convert lines: {0} - {1} in {2}." \
-               " {3} expresion should be converted manualy.\nCode:\n{4}" \
-               "\nChanged to:\n{5}\n{6}".format(self.lineStart + 1, self.lineEnd + 1, self.fileName, self.type.value[0],
-                                                "".join(self.oldValue), "".join(self.codeReplacment), "-" * 100)

--- a/conversion/TemplateConverter.py
+++ b/conversion/TemplateConverter.py
@@ -130,7 +130,7 @@ class TemplateConverter(object):
         :return: string without any new lines
         """
         if (text.endswith("\n")):
-            text = text[:-2]
+            text = text[:-1]
         return text
 
     def convertBlock(self, lineNr):
@@ -452,20 +452,20 @@ def main(opts):
         fileName = FileReader.getFileName(name)
         # get file lines
         fileLines = FileReader.readFile(name)
-        templateConverter = TemplateConverter(fileLines, fileName)
+        templateConverter = TemplateConverter(fileLines, name)
         # get converted lines
         convertedLines = templateConverter.getFileLines()
         # add lines that are inconvertible to the list
-        manualReplacments += map(str, templateConverter.irreversibleDataList)
+        manualReplacments += templateConverter.irreversibleDataList
         fileNames += [x.fileName for x in templateConverter.irreversibleDataList]
-        fileName = fileName + ".html"
+        fileName = fileName + ".tmpl"
         # save jinja2 template
         FileWriter.writeToFile(pathConverted + fileName, convertedLines)
     # save info about inconvertible template
     print(str(len(list(set(
         fileNames)))) + " file(s) need manual conversion. More information can be found in:\n" +
           pathManual + "manualConversions.txt")
-    FileWriter.writeToFile(pathManual + "manualConversions.txt", manualReplacments)
+    FileWriter.writeToFile(pathManual + "manualConversions.txt", FileWriter.convertToString(manualReplacments))
 
 
 if __name__ == "__main__":

--- a/dependencies/resultsCore.deps
+++ b/dependencies/resultsCore.deps
@@ -1,0 +1,50 @@
+Modules not supported in python3: 
+Cheetah --- Convert it to jinja2
+commands ---  Use the subprocess module instead
+Configuration ---  renamed to configparser in Python 3. The 2to3 tool will automatically adapt imports
+couchapp --- Not supported. Should be supported soon. http://stackoverflow.com/questions/5849316/is-there-a-simpler-couchapp-than-couchapp
+mechanize --- Not supported. Use: https://github.com/jmcarp/robobrowser or https://github.com/hickford/MechanicalSoup
+Queue --- Renamed to queue. The 2to3 tool will automatically adapt imports.
+RestClient --- Custom lib. https://github.com/giffels/RestClient
+zmq --- supported https://github.com/zeromq/pyzmq/blob/master/README.md
+--------------------------------------------------
+Modules not found: 
+apmon --- custom lib. Might need to rewrite it after conversion?
+buildslaveconfig --- imports configs. Custom stuff
+classad --- ???? python-condor stuff. http://research.cs.wisc.edu/htcondor/classad/ /WMCore/BossAir/Plugins/PyCondorPlugin.py
+Controllers --- ????? only used in WMCore/src/python/WMCore/WebTools/Masthead.py
+cPickle --- Not supported. Just use normal pickle
+cStringIO --- cStringIO is removed. Use io.StringIO
+dbs ---  Custom lib. CMS Dataset Bookkeeping Service
+dbs3Client -- Custom lib. 
+DBSAPI --- custom lib.
+dbsException --- custom lib. dmwm/DBS – dbsException.py 
+dcap --- not supported. https://github.com/alexanderwaldin/dcap
+FWCore --- custom. https://github.com/cms-sw/cmssw/tree/CMSSW_8_1_X/FWCore
+get_dbs --- custom. Called using __all__
+get_remote_queue --- custom. Called using __all__
+glite_wmsui_LbWrapper --- custom. 'glite_wmsui_LbWrapper' exists on both gLite 3.1 and gLite 3.2
+hotshot --- The "hotshot" module disappeared in Python3.x. It seems it is deprecated although this is not mentioned in the documentation.
+htcondor --- supported. (Is connected with classad)
+httplib --- renamed to http.client in Python 3. The 2to3 tool will automatically adapt imports
+Integration_t --- custom
+IOMC --- custom
+OpenSSL --- supported https://pypi.python.org/pypi/pyOpenSSL
+popen2 --- This module is obsolete. Use the subprocess module.
+PSetTweaks --- custom
+queueConfigFromConfigObject --- custom. From __all__
+queueFromConfig --- --- custom. From __all__
+ReqMgr --- custom
+ReqMgrSecrets --- custom
+StageOut --- custom
+StringIO --- StringIO is removed. Use io.StringIO
+thread ---  renamed to _thread in Python 3. The 2to3 tool will automatically adapt imports 
+urllib2 --- renamed to urllib.request and urllib.error. The 2to3 tool will automatically adapt imports 
+urlparse --- renamed to urllib.parse in Python 3. The 2to3 tool will automatically adapt imports
+WMComponent --- custom
+WMCore --- custom
+WMCore_t --- custom 
+WMQuality --- custom
+WMSandbox --- custom
+wmsui_api --- custom. 'wmsui_api' exists only on gLite 3.2 
+WMTaskSpace --- custom

--- a/dependencies/resultsDAS.deps
+++ b/dependencies/resultsDAS.deps
@@ -1,0 +1,31 @@
+Modules not supported in python3: 
+
+Carbon --- Not supported. Can we remove it? Only used in DAS/src/python/plistlib. Cuuld use: https://docs.python.org/3/library/plistlib.html
+Cheetah --- Convert it to jinja2
+HTMLParser --- Renamed to html.parser. The 2to3 tool will automatically adapt imports
+Plist ---  Not supported. Can we remove it? Only used in DAS/src/python/plistlib. COuld use: https://docs.python.org/3/library/plistlib.html
+Queue --- Renamed to queue. The 2to3 tool will automatically adapt imports.
+tests --- used by pycurl tests. No need to port
+xmlrpclib --- Renamed to xmlrpc.client in Python 3. The 2to3 tool will automatically adapt imports
+yajl - Not supported. Port to https://github.com/rtyler/py-yajl/ or original: https://github.com/pykler/yajl-py:  if using python3, yajl-py expects bytes and not strings
+yaml --- PyYAML - supported
+--------------------------------------------------
+Modules not found: 
+
+antlr3 --- not supported. Port to: https://github.com/antlr/antlr3/tree/master/runtime/Python3
+antrl --- we wrote it. uses antlr3 as dep.
+cjson --- not supported. Only usded in /DAS/test/jsonwrapper_t.py (and init). !!!!!!!!!!
+cookielib --- renamed to http.cookiejar in Python 3. The 2to3 tool will automatically adapt imports
+cPickle --- Not supported. Just use normal pickle
+cStringIO --- cStringIO is removed. Use io.StringIO
+get_schema --- we wrote it.
+gridfs --- supported. Might change datatypes a bit
+httplib ---  renamed to http.client in Python 3. The 2to3 tool will automatically adapt imports 
+jsonpath_rw --- supported
+md5 ---  Use the hashlib.md5 module instead
+memcache --- used in OLD only
+Stemmer  ---- https://pypi.python.org/pypi/PyStemmer supported
+StringIO --- StringIO is removed. Use io.StringIO
+thread ---  renamed to _thread in Python 3. The 2to3 tool will automatically adapt imports 
+urllib2 --- renamed to urllib.request and urllib.error. The 2to3 tool will automatically adapt imports 
+urlparse --- renamed to urllib.parse in Python 3. The 2to3 tool will automatically adapt imports


### PR DESCRIPTION
I'm going go through all DMWM projects.  Later on will commit results of what libraries we need to migrate. So far have few:

DAS:
Plist/Carbon --- Not supported. Only used in DAS/src/python/plistlib. Could use: https://docs.python.org/3/library/plistlib.html  
 yajl - Not supported. Port to https://github.com/rtyler/py-yajl/ or original: https://github.com/pykler/yajl-py:  if using python3, yajl-py expects bytes and not strings
antlr3 --- not supported. Port to: https://github.com/antlr/antlr3/tree/master/runtime/Python3
cjson --- not supported. Only usded in /DAS/test/jsonwrapper_t.py (and init). Not sure about this
cPickle --- Not supported. Just use normal pickle

CORE:
couchapp --- Not supported. Should be supported soon. http://stackoverflow.com/questions/5849316/is-there-a-simpler-couchapp-than-couchapp
mechanize --- Not supported. Use: https://github.com/jmcarp/robobrowser or https://github.com/hickford/MechanicalSoup
dcap --- not supported. https://github.com/alexanderwaldin/dcap

Other libs either we wrote or can be easily ported using some tools (2to3)
